### PR TITLE
modifications for ns3.46.1

### DIFF
--- a/model/quic-bbr.cc
+++ b/model/quic-bbr.cc
@@ -364,7 +364,8 @@ QuicBbr::HandleProbeRTT (Ptr<QuicSocketState> tcb)
 {
   NS_LOG_FUNCTION (this << tcb);
 
-  tcb->m_appLimitedUntil = (tcb->m_delivered + tcb->m_bytesInFlight.Get ()) ?: 1;
+  uint64_t appLimitedUntil = tcb->m_delivered + tcb->m_bytesInFlight.Get ();
+  tcb->m_appLimitedUntil = appLimitedUntil ? appLimitedUntil : 1;
 
   if (m_probeRttDoneStamp == Seconds (0) && tcb->m_bytesInFlight <= m_minPipeCwnd)
     {

--- a/model/quic-l4-protocol.cc
+++ b/model/quic-l4-protocol.cc
@@ -695,7 +695,7 @@ QuicL4Protocol::CreateSocket (TypeId congestionTypeId)
         }
     }
   socket->SetConnectionId (connectionId);
-  Ptr<QuicUdpBinding> udpBinding = Create<QuicUdpBinding> ();
+  Ptr<QuicUdpBinding> udpBinding = CreateObject<QuicUdpBinding> ();
   udpBinding->m_budpSocket = nullptr;
   udpBinding->m_budpSocket6 = nullptr;
   udpBinding->m_quicSocket = socket;

--- a/model/quic-l4-protocol.cc
+++ b/model/quic-l4-protocol.cc
@@ -98,14 +98,6 @@ QuicUdpBinding::GetTypeId (void)
   return tid;
 }
 
-TypeId
-QuicUdpBinding::GetInstanceTypeId (void) const
-{
-  return GetTypeId ();
-}
-
-
-
 #undef NS_LOG_APPEND_CONTEXT
 #define NS_LOG_APPEND_CONTEXT                                   \
   if (m_node) { std::clog << " [node " << m_node->GetId () << "] "; }

--- a/model/quic-l4-protocol.h
+++ b/model/quic-l4-protocol.h
@@ -55,7 +55,6 @@ public:
   ~QuicUdpBinding ();
 
   static TypeId GetTypeId (void);
-  TypeId GetInstanceTypeId (void) const;
 
   Ptr<Socket> m_budpSocket;          //!< The UDP socket this binding is associated with
   Ptr<Socket> m_budpSocket6;         //!< The IPv6 UDP this binding is associated with

--- a/model/quic-socket-base.cc
+++ b/model/quic-socket-base.cc
@@ -1302,7 +1302,8 @@ QuicSocketBase::SendDataPacket (SequenceNumber32 packetNumber,
   if (sz < maxSize and m_txBuffer->AppSize () == 0 and m_tcb->m_bytesInFlight.Get () < m_tcb->m_cWnd)
     {
       NS_LOG_LOGIC ("Connection is Application-Limited. sz = " << sz << " < maxSize = " << maxSize);
-      m_tcb->m_appLimitedUntil = m_tcb->m_delivered + m_tcb->m_bytesInFlight.Get () ? : 1U;
+      uint64_t appLimitedUntil = m_tcb->m_delivered + m_tcb->m_bytesInFlight.Get ();
+      m_tcb->m_appLimitedUntil = appLimitedUntil ? appLimitedUntil : 1U;
     }
 
   // perform pacing

--- a/model/quic-socket-base.cc
+++ b/model/quic-socket-base.cc
@@ -79,12 +79,6 @@ NS_OBJECT_ENSURE_REGISTERED (QuicSocketState);
 const uint16_t QuicSocketBase::MIN_INITIAL_PACKET_SIZE = 1200;
 
 TypeId
-QuicSocketBase::GetInstanceTypeId () const
-{
-  return QuicSocketBase::GetTypeId ();
-}
-
-TypeId
 QuicSocketBase::GetTypeId (void)
 {
   static TypeId tid = TypeId ("ns3::QuicSocketBase")

--- a/model/quic-socket-base.h
+++ b/model/quic-socket-base.h
@@ -180,12 +180,6 @@ public:
   static TypeId GetTypeId (void);
 
   /**
-   * \brief Get the instance TypeId
-   * \return the instance TypeId
-   */
-  virtual TypeId GetInstanceTypeId () const;
-
-  /**
    * \brief Build an object. InitializeScheduling() must be called after construction to instantiate the frame scheduler, or the construction will fail
    *
    */

--- a/model/quic-stream-base.cc
+++ b/model/quic-stream-base.cc
@@ -72,13 +72,6 @@ QuicStreamBase::GetTypeId (void)
   return tid;
 }
 
-TypeId
-QuicStreamBase::GetInstanceTypeId () const
-{
-  return QuicStreamBase::GetTypeId ();
-}
-
-
 QuicStreamBase::QuicStreamBase (void)
   : QuicStream (),
   m_streamType (NONE),

--- a/model/quic-stream-base.h
+++ b/model/quic-stream-base.h
@@ -59,12 +59,6 @@ public:
    */
   static TypeId GetTypeId (void);
 
-  /**
-   * \brief Get the instance TypeId
-   * \return the instance TypeId
-   */
-  virtual TypeId GetInstanceTypeId () const;
-
   QuicStreamBase (void);
   virtual ~QuicStreamBase (void);
 

--- a/model/quic-stream-tx-buffer.cc
+++ b/model/quic-stream-tx-buffer.cc
@@ -36,6 +36,17 @@ namespace ns3 {
 
 NS_LOG_COMPONENT_DEFINE ("QuicStreamTxBuffer");
 
+TypeId
+QuicStreamTxItem::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::QuicStreamTxItem")
+    .SetParent<Object> ()
+    .SetGroupName ("Internet")
+    .AddConstructor<QuicStreamTxItem> ();
+  return tid;
+}
+
+
 QuicStreamTxItem::QuicStreamTxItem ()
   : m_packetNumberSequence (0),
     m_packet (0),

--- a/model/quic-stream-tx-buffer.h
+++ b/model/quic-stream-tx-buffer.h
@@ -41,6 +41,12 @@ namespace ns3 {
 class QuicStreamTxItem : public Object
 {
 public:
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId (void);
+  
   QuicStreamTxItem ();
   QuicStreamTxItem (const QuicStreamTxItem &other);
   ~QuicStreamTxItem ();

--- a/test/quic-rx-buffer-test.cc
+++ b/test/quic-rx-buffer-test.cc
@@ -201,7 +201,7 @@ QuicRxBufferTestCase::TestSocketExtract ()
   NS_TEST_ASSERT_MSG_EQ(rxBuf.Available (), 3600,
                         "Availability differs from expected");
   NS_TEST_ASSERT_MSG_EQ(rxBuf.Size (), 0, "Buffer size differs from expected");
-  NS_TEST_ASSERT_MSG_NE(!out, true, "Packet size differs from expected");
+  NS_TEST_ASSERT_MSG_EQ(!out, true, "Packet size differs from expected");
 }
 
 void
@@ -356,7 +356,7 @@ QuicRxBufferTestCase::TestStreamExtract ()
 
   // test empty buffer
   outPkt = rxBuf.Extract(1200);
-  NS_TEST_ASSERT_MSG_NE(!outPkt, true, "Failed to extract packets");
+  NS_TEST_ASSERT_MSG_EQ(!outPkt, true, "Failed to extract packets");
   NS_TEST_ASSERT_MSG_EQ(rxBuf.Available (), 18000, "Wrong available data size");
   NS_TEST_ASSERT_MSG_EQ(rxBuf.Size (), 0, "Wrong buffer size");
 }


### PR DESCRIPTION
Created by https://github.com/a-andre/quic for ns3.42.
I made the necessary modifications for ns3.46.1.

- `GetInstanceTypeId()` is now non-overridable, so I removed its usage. [details](https://gitlab.com/nsnam/ns-3-dev/-/commit/af9b91a791ee6cdf0b777974edf4dac436e6925b) #1
- `Object` creation should use `CreateObject()`, but `Create()` was used. [details](https://gitlab.com/nsnam/ns-3-dev/-/commit/0ef77eab92b078d6815664eae93d59b63e772364) #2
- The ?: syntax was used, which violates ISO. #3
- There was error in the test code. #4
- There were places where GetTypeId() was not implemented. #5