### PR TITLE
Fix cmakelists and includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,48 +1,60 @@
 build_lib(
   LIBNAME quic
   SOURCE_FILES
-    model/quic-congestion-ops.cc
-    model/quic-socket.cc
-    model/quic-socket-base.cc
-    model/quic-socket-factory.cc
-    model/quic-l4-protocol.cc
+    helper/quic-helper.cc
     model/quic-socket-rx-buffer.cc
+    model/quic-header.cc
+    model/quic-congestion-ops.cc
+    model/quic-stream-tx-buffer.cc
     model/quic-socket-tx-buffer.cc
+    model/quic-bbr.cc
+    model/quic-subheader.cc
     model/quic-socket-tx-scheduler.cc
-    model/quic-socket-tx-pfifo-scheduler.cc
+    model/quic-l4-protocol.cc
+    model/quic-socket.cc
+    model/quic-stream-rx-buffer.cc
     model/quic-socket-tx-edf-scheduler.cc
     model/quic-stream.cc
     model/quic-stream-base.cc
-    model/quic-l5-protocol.cc
-    model/quic-stream-tx-buffer.cc
-    model/quic-stream-rx-buffer.cc
-    model/quic-header.cc
-    model/quic-subheader.cc
+    model/quic-socket-tx-pfifo-scheduler.cc
+    model/quic-socket-factory.cc
     model/quic-transport-parameters.cc
-    model/quic-bbr.cc
-    helper/quic-helper.cc
+    model/quic-l5-protocol.cc
+    model/quic-socket-base.cc
+    quic-applications/helper/quic-client-server-helper.cc
+    quic-applications/helper/quic-echo-helper.cc
+    quic-applications/model/quic-client.cc
+    quic-applications/model/quic-echo-client.cc
+    quic-applications/model/quic-echo-server.cc
+    quic-applications/model/quic-server.cc
   HEADER_FILES
-    model/quic-congestion-ops.h
-    model/quic-socket.h
-    model/quic-socket-base.h
-    model/quic-socket-factory.h
-    model/quic-l4-protocol.h
-    model/quic-socket-rx-buffer.h
-    model/quic-socket-tx-buffer.h
-    model/quic-socket-tx-scheduler.h
-    model/quic-socket-tx-pfifo-scheduler.h
+    helper/quic-helper.h
     model/quic-socket-tx-edf-scheduler.h
-    model/quic-stream.h
+    model/quic-socket-rx-buffer.h
+    model/quic-socket-base.h
+    model/quic-socket-tx-pfifo-scheduler.h
     model/quic-stream-base.h
+    model/quic-congestion-ops.h
     model/quic-l5-protocol.h
-    model/quic-stream-tx-buffer.h
     model/quic-stream-rx-buffer.h
+    model/quic-socket.h
+    model/quic-socket-tx-scheduler.h
+    model/quic-l4-protocol.h
+    model/quic-bbr.h
     model/quic-header.h
     model/quic-subheader.h
     model/quic-transport-parameters.h
-    model/quic-bbr.h
-    helper/quic-helper.h
+    model/quic-stream.h
+    model/quic-socket-factory.h
+    model/quic-socket-tx-buffer.h
+    model/quic-stream-tx-buffer.h
     model/windowed-filter.h
+    quic-applications/helper/quic-client-server-helper.h
+    quic-applications/helper/quic-echo-helper.h
+    quic-applications/model/quic-echo-client.h
+    quic-applications/model/quic-server.h
+    quic-applications/model/quic-client.h
+    quic-applications/model/quic-echo-server.h
   LIBRARIES_TO_LINK ${libinternet}
                     ${libapplications}
                     ${libflow-monitor}

--- a/quic-applications/model/quic-client.cc
+++ b/quic-applications/model/quic-client.cc
@@ -29,7 +29,7 @@
 #include "ns3/packet.h"
 #include "ns3/uinteger.h"
 #include "quic-client.h"
-#include "seq-ts-header.h"
+#include "ns3/seq-ts-header.h"
 #include <cstdlib>
 #include <cstdio>
 

--- a/quic-applications/model/quic-server.cc
+++ b/quic-applications/model/quic-server.cc
@@ -30,9 +30,9 @@
 #include "ns3/packet.h"
 #include "ns3/uinteger.h"
 #include "ns3/string.h"
-#include "packet-loss-counter.h"
+#include "ns3/packet-loss-counter.h"
 
-#include "seq-ts-header.h"
+#include "ns3/seq-ts-header.h"
 #include "quic-server.h"
 
 namespace ns3 {

--- a/quic-applications/model/quic-server.h
+++ b/quic-applications/model/quic-server.h
@@ -27,7 +27,7 @@
 #include "ns3/event-id.h"
 #include "ns3/ptr.h"
 #include "ns3/address.h"
-#include "packet-loss-counter.h"
+#include "ns3/packet-loss-counter.h"
 #include <iostream>
 #include <fstream>
 


### PR DESCRIPTION
Some code was excluded from the CMakeLists. This is likely because it was forgotten to be added when porting from the original quic-ns-3.
It is also believed that the include specifications were forgotten to be corrected when porting.

It may be possible to dismantle quic-applications and integrate it into helper and model, but we will maintain the original repository as much as possible.