### PR TITLE
fix examples cmakelists

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,13 +6,13 @@ set(base_examples
     quic-variants-comparison
 )
 
-foreach(
-  example
-  ${base_examples}
-)
+foreach(example IN LISTS base_examples)
   build_lib_example(
     NAME ${example}
     SOURCE_FILES ${example}.cc
+    LIBRARIES_TO_LINK
+      ${libcore}
+      ${libquic}
     LIBRARIES_TO_LINK
       ${libcore}
       ${libquic}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,11 +1,24 @@
-build_lib_example(
-  NAME quic-variants-comparison-bulksend
-  SOURCE_FILES quic-variants-comparison-bulksend.cc
-  LIBRARIES_TO_LINK
-    ${libcore}
-    ${libquic}
-    ${libinternet}
-    ${libapplications}
-    ${libflow-monitor}
-    ${libpoint-to-point}
+set(base_examples
+    quic-pacing
+    quic-tester
+    quic-tester-streams
+    quic-variants-comparison-bulksend
+    quic-variants-comparison
 )
+
+foreach(
+  example
+  ${base_examples}
+)
+  build_lib_example(
+    NAME ${example}
+    SOURCE_FILES ${example}.cc
+    LIBRARIES_TO_LINK
+      ${libcore}
+      ${libquic}
+      ${libinternet}
+      ${libapplications}
+      ${libflow-monitor}
+      ${libpoint-to-point}
+  )
+endforeach()


### PR DESCRIPTION
The code in the examples that was missing from cmakelists was corrected.